### PR TITLE
fix: default imported players to present

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -122,7 +122,13 @@ export default function PloufPloufBaby() {
     reader.onload = () => {
       try {
         const json = JSON.parse(String(reader.result));
-        if (Array.isArray(json.players)) setPlayers(json.players.map(p => ({ id: p.id || uid(), name: p.name, present: !!p.present })));
+        if (Array.isArray(json.players)) setPlayers(
+          json.players.map(p => ({
+            id: p.id || uid(),
+            name: p.name,
+            present: p.present !== false,
+          }))
+        );
       } catch {}
     };
     reader.readAsText(file);


### PR DESCRIPTION
## Summary
- ensure imported players are marked present unless explicitly set to false

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689c938c54dc832c87690dfcd0d47bed