### PR TITLE
Fix tailwind setup for Docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+node_modules
+/dist
+
+package-lock.json
+
+# local env files
+.env
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,8 @@ WORKDIR /app
 # Copie package.json et lockfile (si tu en as un)
 COPY package*.json ./
 
-# Installe les dépendances + Tailwind/PostCSS
-RUN npm install --no-audit --no-fund && \
-    npm install -D tailwindcss postcss autoprefixer && \
-    npx tailwindcss init -p
+# Installe les dépendances
+RUN npm install --no-audit --no-fund
 
 # Copie tout le reste du projet
 COPY . .

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.17",
     "vite": "^5.0.0"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- pin and configure Tailwind v3 in the app
- simplify Docker build to use installed dependencies
- add PostCSS config and ignore node_modules

## Testing
- `npm install --no-audit --no-fund`
- `npm run build`
- `docker-compose build` *(fails: Error while fetching server API version)*

------
https://chatgpt.com/codex/tasks/task_e_689c96996268832c972c1fbdd5edae58