### PR TITLE
Store SQLite database in data directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 /dist
 
 package-lock.json
+data
 
 # local env files
 .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       - "5002:80"
     restart: unless-stopped
     volumes:
-      - plouf_data:/app/players.db
+      - plouf_data:/app/data
 
 volumes:
   plouf_data:

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ import { open } from 'sqlite';
 import sqlite3 from 'sqlite3';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import fs from 'fs/promises';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -10,8 +11,10 @@ const __dirname = path.dirname(__filename);
 const uid = () => Math.random().toString(36).slice(2, 10);
 
 async function createDb() {
+  const dbPath = path.join(__dirname, 'data', 'players.db');
+  await fs.mkdir(path.dirname(dbPath), { recursive: true });
   const db = await open({
-    filename: path.join(__dirname, 'players.db'),
+    filename: dbPath,
     driver: sqlite3.Database,
   });
   await db.exec(`CREATE TABLE IF NOT EXISTS players (


### PR DESCRIPTION
## Summary
- Persist SQLite database under a `data` directory
- Mount Docker volume to `/app/data` instead of a single file
- Ignore generated database files in Git

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_689ca0b6688c832c97a8cf3f07f586ba